### PR TITLE
Add verbose flag which reports upload bandwidth and open connections while waiting for status change

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
+	github.com/dustin/go-humanize v1.0.0
 	github.com/elastic/gosigar v0.12.0 // indirect
 	github.com/fatih/color v1.7.0 // indirect
 	github.com/flynn/noise v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -166,6 +166,7 @@ github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUn
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/main.go
+++ b/main.go
@@ -196,7 +196,7 @@ func main() {
 					var bwc *metrics.BandwidthCounter
 
 					if c.Bool(verboseFlag.Name) {
-						bwc := metrics.NewBandwidthCounter()
+						bwc = metrics.NewBandwidthCounter()
 						config = append(config, libp2p.BandwidthReporter(bwc))
 					}
 
@@ -313,7 +313,7 @@ func main() {
 						if c.Bool(verboseFlag.Name) {
 							// output bandwidth information
 							st := bwc.GetBandwidthForProtocol("/ipfs/bitswap/1.2.0")
-							s.Suffix = fmt.Sprintf("upload rate: %s/s (connections: %d)\n", humanize.Bytes(uint64(st.RateOut)), len(host.Network().Conns()))
+							s.Suffix = fmt.Sprintf("upload rate: %s/s | total uploaded: %s (connections: %d)\n", humanize.Bytes(uint64(st.RateOut)), humanize.Bytes(uint64(st.TotalOut)), len(host.Network().Conns()))
 						}
 
 						if pinRequest.GetStatus() != current.GetStatus() {

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dustin/go-humanize"
 	"github.com/ipfs/go-cid"
 	pinclient "github.com/ipfs/go-pinning-service-http-client"
 	"github.com/ipld/go-car/v2"
@@ -19,6 +20,7 @@ import (
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p-core/event"
 	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/metrics"
 	"github.com/libp2p/go-libp2p-core/peer"
 	routinghelpers "github.com/libp2p/go-libp2p-routing-helpers"
 	"github.com/multiformats/go-multiaddr"
@@ -55,6 +57,10 @@ var (
 
 	nameFlag = &cli.StringFlag{
 		Name: "name", Usage: "Optional name for pinned data; can be used for lookups later", Required: false,
+	}
+
+	verboseFlag = &cli.BoolFlag{
+		Name: "verbose", Usage: "Show open connections and Bitswap upload bandwith", Required: false,
 	}
 )
 
@@ -150,6 +156,7 @@ func main() {
 					tokenFlag,
 					nameFlag,
 					passOrigins,
+					verboseFlag,
 				},
 				Action: func(c *cli.Context) error {
 					endpoint, err := getServiceEndpoint(c.String(serviceFlag.Name))
@@ -185,6 +192,13 @@ func main() {
 					pinClient := pinclient.NewClient(endpoint, c.String(tokenFlag.Name)) // instantiate client with token
 
 					config := []libp2p.Option{}
+
+					var bwc *metrics.BandwidthCounter
+
+					if c.Bool(verboseFlag.Name) {
+						bwc := metrics.NewBandwidthCounter()
+						config = append(config, libp2p.BandwidthReporter(bwc))
+					}
 
 					if c.Bool(passOrigins.Name) {
 						// To pass the origins we typically need to port map assuming we're behind NAT
@@ -294,6 +308,12 @@ func main() {
 						if err != nil {
 							fmt.Println("failed getting pin request status")
 							continue
+						}
+
+						if c.Bool(verboseFlag.Name) {
+							// output bandwidth information
+							st := bwc.GetBandwidthForProtocol("/ipfs/bitswap/1.2.0")
+							s.Suffix = fmt.Sprintf("upload rate: %s/s (connections: %d)\n", humanize.Bytes(uint64(st.RateOut)), len(host.Network().Conns()))
 						}
 
 						if pinRequest.GetStatus() != current.GetStatus() {


### PR DESCRIPTION
This introduces a new flag which provides visibility into the number of open connections to the libp2p host and upload bandwidth speed.